### PR TITLE
Create docs, CI

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+---
+title: "Home"
+nav_order: 1
+---
+
+# Reana JupyterLab Extension
+[![Install dependencies and build](https://github.com/vre-hub/reana-jupyterlab-extension/actions/workflows/build-and-publish.yml/badge.svg)](https://github.com/vre-hub/reana-jupyterlab-extension/actions/workflows/build-and-publish.yml/badge.svg)
+
+Reana JupyterLab plugin provides a set of tools to interact with the [Reana](https://reanahub.io/) workflow management system from within JupyterLab. 
+
+**This project is currently in development and is subject to change.**
+
+## Requirements
+- JupyterLab>=4,<5
+- Notebook<7
+- Node.js==20
+- [Custom version of `reana-client`](https://github.com/mdonadoni/reana-client/tree/vre-summer-24)

--- a/docs/introduction/about.md
+++ b/docs/introduction/about.md
@@ -1,0 +1,13 @@
+---
+title: "What is Reana JupyterLab extension?"
+parent: "Introduction"
+nav_order: 1
+---
+
+Reana Jupyterlab extension is a JupyterLab plugin that implements the basic functionalities of the [REANA](https://reanahub.io/) workflow management system. The plugin allows users to interact with the REANA server from within JupyterLab, providing a seamless experience for users who want to run their workflows on the REANA platform.
+
+This project is being developed as a part of the Virtual Research Environment ([VRE](https://github.com/vre-hub)) initiative, created as a part of the [ESCAPE Collaboration](https://projectescape.eu/). The end goal of the VRE is to develop a Hub which aggregates software and infrastructure to create an end-to-end analysis facility for physicists.
+
+This project is currently in development and is subject to change. We are open to contributions and feedback from the community.
+
+[Reana JupyterLab extension repository](https://github.com/vre-hub/reana-jupyterlab-extension)

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -1,0 +1,5 @@
+---
+title: "Getting started"
+nav_order: 2
+has_children: true
+---

--- a/docs/introduction/installation/developers.md
+++ b/docs/introduction/installation/developers.md
@@ -1,0 +1,38 @@
+---
+title: "Guide for developers"
+parent: "Installation"
+nav_order: 2
+---
+
+# Installation from source
+The following instructions are for developers who want to install the extension from source.
+
+Install Python dependencies
+```bash
+python -m pip install -r requirements.txt
+```
+
+Install Yarn dependencies
+```bash
+jlpm install
+```
+
+Build the extension
+```bash
+jlpm run build
+```
+
+Install the extension
+```bash
+python -m pip install .
+```
+
+Enable the server extension
+```bash
+jupyter server extension enable --py reana_jupyterlab
+```
+
+Finally, open a JupyterLab instance. The extension should be available in the JupyterLab sidebar.
+```bash
+jupyter lab
+```

--- a/docs/introduction/installation/index.md
+++ b/docs/introduction/installation/index.md
@@ -1,0 +1,6 @@
+---
+title: "Installation"
+parent: "Introduction"
+nav_order: 2
+has_children: true
+---

--- a/docs/introduction/installation/users.md
+++ b/docs/introduction/installation/users.md
@@ -1,0 +1,21 @@
+---
+title: "Guide for users"
+parent: "Installation"
+nav_order: 1
+---
+
+# Intallation via pip
+
+To install the extension, run the following command:
+```bash
+pip install reana-jupyterlab
+```
+
+# Docker image
+It is possible to run the extension in a Docker container. To download and run the image, use the following commands:
+```bash
+docker pull ghcr.io/vre-hub/reana-jupyterlab-extension:<version>
+docker run -d -p 8888:8888 ghcr.io/vre-hub/reana-jupyterlab-extension
+```
+
+All the available versions can be found [here](https://github.com/vre-hub/reana-jupyterlab-extension/pkgs/container/reana-jupyterlab-extension).

--- a/docs/usage/connection.md
+++ b/docs/usage/connection.md
@@ -1,0 +1,15 @@
+---
+title: "Connection to REANA server"
+parent: "Usage"
+nav_order: 1
+---
+
+To connect to a REANA server, you need to provide the server URL and your access token. The server URL is the URL of the REANA server you want to connect to. The access token is a secret key that allows you to authenticate with the REANA server.
+
+To connect to a REANA server, follow these steps:
+
+1. Open the REANA extension by clicking on the REANA icon in the JupyterLab sidebar.
+2. Enter the server URL and access token in the corresponding fields.
+3. Click on the "Connect" button to save the settings.
+
+After connecting to the REANA server, a notification will appear in the bottom right corner of the screen indicating that the connection was successful. You can now interact with the REANA server from within JupyterLab.

--- a/docs/usage/create.md
+++ b/docs/usage/create.md
@@ -1,0 +1,15 @@
+---
+title: "Create a new workflow"
+parent: "Usage"
+nav_order: 3
+---
+
+
+Users can create new workflows from the virtual environment by using the REANA extension. The extension provides a user-friendly interface for creating new workflows and managing existing ones. To create a new workflow, follow these steps:
+
+1. Open the REANA extension by clicking on the REANA icon in the JupyterLab sidebar.
+2. Click on the "Create" tab.
+3. Enter the workflow name. The name does not need to be unique (it will be considered as a new run of the workflow). The extension will only accept alphanumeric characters and underscores.
+4. Click on the folder icon in the "YAML file" field to select the YAML file that defines the workflow. It will open a file browser in the root directory of the virtual environment. After selecting the YAML file, the path to the file will be displayed in the field. If you want to select a different file, click on the folder icon again. If you want to remove the file, click on the "X" icon.
+5. (Optional) You can validate the YAML file by clicking on the "Validate" button. The extension will check the syntax of the YAML file and display the output on the screen. If the output is an error, the message will be displayed in a red box, otherwise, it will be displayed in a blue box.
+6. Click on the "Create & Run" button to create the workflow, upload the workspace and start the workflow. A message will be displayed, indicating that the workflow was created successfully (or the error). The workflow should be displayed in the "Workflows" tab of the extension.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,0 +1,5 @@
+---
+title: "Usage"
+nav_order: 3
+has_children: true
+---

--- a/docs/usage/workflows.md
+++ b/docs/usage/workflows.md
@@ -1,0 +1,27 @@
+---
+title: "Workflow management"
+parent: "Usage"
+nav_order: 2
+---
+
+# Workflows list
+
+The "Workflows" tab displays a list of all the workflows that have been created by the user. The list includes information about the workflow, such as the name the run number and the status. The user can interact with the workflows by clicking on any workflow.
+
+The user can filter the list of workflows by using the search bar at the top of the tab. The search bar allows the user to search for workflows by name. There is also a status filter that allows the user to filter the workflows by their status, and a sort button that allows the user to sort the workflows by date in ascending or descending order.
+
+The user can also refresh the list of workflows by clicking on the refresh button at the top of the tab.
+
+# Workflow details
+
+When the user clicks on a workflow in the list, the "Workflows" tab will display the details of the workflow. The details include more information about the workflow. On top of that, there are four tabs that allow the user to interact with the workflow:
+
+- **Engine logs:** Displays the engine logs of the workflow, which includes information about the execution of the workflow.
+
+- **Job logs:** Displays the job logs and information about each step of the workflow. The user can use the dropdown menu to select the step they want to see the logs for.
+
+- **Workspace:** Displays the workspace of the workflow. The user can browse in the workspace by name. If the users want to download the whole workspace to the virtual environment, they can click on the download button next to the search bar. If they want to download specific files, they can select the files by clicking on them and then click on the download button.
+
+After the download, a notification should appear at the bottom right of the screen with the number of files downloaded, and a new directory with the name and run of the workflow should appear in the root directory of the virtual environment.
+
+- **Specification:** Displays the specification and runtime parameters of the workflow. 


### PR DESCRIPTION
Still in progress, don't merge yet.

I created a small index and used the [jekyll-gh-pages workflow](https://github.com/actions/starter-workflows/blob/main/pages/jekyll-gh-pages.yml) to build the docs automatically (on pushes targeting `main`). We can also trigger the workflow when pushing to `docs`, but we would need to modify the protection rule for the `github-pages` environment.