### PR TITLE
Zenodo publication

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,34 @@
+{
+    "creators": [
+        {
+            "orcid": "0000-0001-6262-647X",
+            "affiliation": "University of Granada, CERN",
+            "name": "Pérez-Mercado, Rubén"
+        },
+        {
+            "orcid":"0000-0003-2224-4594",
+            "affiliation": "CERN",
+            "name": "García-García, Enrique"
+        },
+        {
+            "orcid":"0000-0002-3403-1177",
+            "affiliation": "CERN",
+            "name": "Guerrieri, Giovanni"
+        }
+    ],
+
+    "license": "Apache-2.0",
+    "keywords": [
+        "REANA",
+        "JupyterLab",
+        "VRE",
+        "Analysis facilities",
+        "Re-analysis",
+        "Preservation",
+        "Reproducibility",
+        "Reinterpretation"
+    ],
+    "communities": [
+        {"identifier": "ESCAPE"}
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,9 @@
 {
+    "title": "REANA JupyterLab extension",
     "creators": [
         {
             "orcid": "0000-0001-6262-647X",
-            "affiliation": "University of Granada, CERN",
+            "affiliation": "CERN",
             "name": "Pérez-Mercado, Rubén"
         },
         {
@@ -29,6 +30,6 @@
         "Reinterpretation"
     ],
     "communities": [
-        {"identifier": "ESCAPE"}
+        {"identifier": "escape2020"}
     ]
 }


### PR DESCRIPTION
Once this PR is merged, we can release `reana-jupyterlab v1.0.0`, and it will automatically upload the software to Zenodo. After that, we can include the Zenodo badge in the README and the VRE Docs (we also had pending to remove the `-d` from the `docker run` command there).