### PR TITLE
fix(backend): workspace in deleted wf (#38)

### DIFF
--- a/reana_jupyterlab/handlers/workflows.py
+++ b/reana_jupyterlab/handlers/workflows.py
@@ -139,12 +139,16 @@ class WorkflowWorkspaceHandler(APIHandler):
         try:
             response = requests.get(f"{server_url}/api/{endpoint}/{workflow_id}/workspace?{string_params}")
             data = response.json()
+
+            if response.status_code != 200:
+                raise Exception(data.get('message', 'Error getting workspace files'))
+            
             data['files'] = self._parse_files(data.pop('items'))
             self.finish(data)
         except Exception as e:
             self.finish(json.dumps({
                 'status': 'error',
-                'message': str(e)
+                'message': str(e),
             }))
 
 class WorkflowSpecificationHandler(APIHandler):

--- a/reana_jupyterlab/tests/mocks/workflows.py
+++ b/reana_jupyterlab/tests/mocks/workflows.py
@@ -42,6 +42,10 @@ WF1_FILES = {
     ]
 }
 
+DELETED_WF_FILES = {
+    "message": "Workflow workspace was deleted"
+}
+
 WF1_FILES_RESPONSE = {
     "files": [
         {

--- a/reana_jupyterlab/tests/test_workflows.py
+++ b/reana_jupyterlab/tests/test_workflows.py
@@ -42,6 +42,14 @@ def mock_get_workspace(mocker):
     mocker.patch('requests.get', return_value=response)
 
 @pytest.fixture
+def mock_get_workspace_deleted(mocker):
+    response = mocker.Mock()
+    response.json.return_value = DELETED_WF_FILES.copy()
+    response.status_code = 400
+
+    mocker.patch('requests.get', return_value=response)
+
+@pytest.fixture
 def mock_get_specification(mocker):
     response = mocker.Mock()
     response.json.return_value = WF1_SPECIFICATION.copy()
@@ -144,6 +152,15 @@ async def test_get_workspace(jp_fetch, endpoint, mock_get_workspace):
 
     assert response.code == 200
     assert data == WF1_FILES_RESPONSE
+
+
+@pytest.mark.parametrize('endpoint', ['/reana_jupyterlab/workflows/mock_wf_id_1/workspace'])
+async def test_get_workspace_deleted(jp_fetch, endpoint, mock_get_workspace_deleted):
+    response = await jp_fetch(endpoint)
+    data = json.loads(response.body)
+
+    assert response.code == 200
+    assert data['message'] == DELETED_WF_FILES['message']
 
 @pytest.mark.parametrize('endpoint', ['/reana_jupyterlab/workflows/mock_wf_id_1/specification'])
 async def test_get_specification(jp_fetch, endpoint, mock_get_specification):

--- a/src/components/@Workflows/WorkflowWorkspace.tsx
+++ b/src/components/@Workflows/WorkflowWorkspace.tsx
@@ -85,6 +85,10 @@ const useStyles = createUseStyles({
     },
     transparent: {
         opacity: 0.5
+    },
+    message: {
+        padding: '16px',
+        textAlign: 'center'
     }
 });
 
@@ -116,12 +120,14 @@ export const WorkflowWorkspace: React.FC<MyProps> = ({ workflow, setWorkflow, is
         if (loading) {
             const populateWorkflow = async () => {
                 try {
-                    const wfName = workflow.name + '.' + workflow.run;
-                    const dataWorkspace = await requestAPI<any>(`workflows/${wfName}/workspace?page=${page}&search=${query}`, {
-                        method: 'GET',
-                    });
-                    setWorkflow({ ...workflow, ...dataWorkspace });
-                    setNavigation({...navigation, ...dataWorkspace});
+                    if (workflow.status !== 'deleted') {
+                        const wfName = workflow.name + '.' + workflow.run;
+                        const dataWorkspace = await requestAPI<any>(`workflows/${wfName}/workspace?page=${page}&search=${query}`, {
+                            method: 'GET',
+                        });
+                        setWorkflow({ ...workflow, ...dataWorkspace });
+                        setNavigation({...navigation, ...dataWorkspace});
+                    }
                 } catch (e) {
                     console.error(e);
                 } finally {
@@ -193,6 +199,14 @@ export const WorkflowWorkspace: React.FC<MyProps> = ({ workflow, setWorkflow, is
             setSelectedFiles(selectedFiles.filter(f => f !== file))
             :
             setSelectedFiles([...selectedFiles, file]);
+    }
+
+    if (workflow.status === 'deleted') {
+        return (
+            <div className={classes.content}>
+                <p className={classes.message}>The workflow workspace was deleted.</p>
+            </div>
+        );
     }
 
     if (loading) {


### PR DESCRIPTION
- Add condition in `WorkflowWorkspaceHandler` to check if the response contains an error message.
- Add the deleted message in the frontend (as we already have the status, we can skip the API call directly).
- Add test to confirm the backend works.