### PR TITLE
fix: enhance installation instructions and improve backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Reana JupyterLab plugin provides a set of tools to interact with the [Reana](htt
 ## Installation guide for users
 To install the extension, run the following command:
 ```bash
-pip install reana-jupyterlab
+python -m pip install reana-jupyterlab
 ```
 
 In case you want to run the tests, install the extension with the following command:
 ```bash
-pip install reana-jupyterlab[dev]
+python -m pip install reana-jupyterlab[dev]
 ```
 
 ### Docker image
@@ -52,17 +52,18 @@ Build the extension
 jlpm run build
 ```
 
-Install the extension (including the testing dependencies)
+Install the extension in editable mode and include the development dependencies:
 ```bash
-python -m pip install .[dev]
+python -m pip install -e .
+python -m pip install ".[dev]"
 ```
 
 Enable the server extension
 ```bash
-jupyter server extension enable --py reana_jupyterlab
+python -m jupyter server extension enable --py reana_jupyterlab.server
 ```
 
 Finally, open a JupyterLab instance. The extension should be available in the JupyterLab sidebar.
 ```bash
-jupyter lab
+python -m jupyter lab
 ```

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ python -m jupyter server extension enable --py reana_jupyterlab.server
 
 Finally, open a JupyterLab instance. The extension should be available in the JupyterLab sidebar.
 ```bash
-python -m jupyter lab
+python -m jupyter lab --autoreload
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Build the extension
 jlpm run build
 ```
 
+Enable watch mode in a separate terminal to automatically rebuild the extension on changes:
+```bash
+jlpm watch
+```
+
 Install the extension in editable mode and include the development dependencies:
 ```bash
 python -m pip install -e .

--- a/reana_jupyterlab/__init__.py
+++ b/reana_jupyterlab/__init__.py
@@ -19,3 +19,10 @@ def _jupyter_server_extension_points():  # pragma: no cover
     return [{
         "module": "reana_jupyterlab.server"
     }]
+
+# Import and expose the server extension loading function for backward compatibility
+# Fixes `X Validation failed: validation failed` error
+
+from .server import _load_jupyter_server_extension
+
+load_jupyter_server_extension = _load_jupyter_server_extension


### PR DESCRIPTION
This pull request introduces updates to the `README.md` file to improve installation instructions and modifies the `reana_jupyterlab/__init__.py` file to address a compatibility issue. The most important changes include clarifying installation commands, enabling the server extension correctly, and fixing a validation error by exposing a server extension loading function.

### Documentation updates:

* `README.md`: Updated installation commands to use `python -m pip` consistently for better compatibility
* Clarified the process for installing the extension in editable mode with development dependencies
* Adjusted the command for enabling the server extension to specify the correct module path (`reana_jupyterlab.server`).

### Compatibility fix:

* [`reana_jupyterlab/__init__.py`](diffhunk://#diff-af7cd2ae3a0a9af1bd90d9d392fffcc35525f31376ff1f060148acf0334feec1R22-R28): Imported and exposed the `_load_jupyter_server_extension` function from the `server` module to ensure backward compatibility and resolve the following validation error:
```
(.venv) tomondre@tondrejk-1 reana-jupyterlab-extension % python -m jupyter server extension enable --py reana_jupyterlab.server
A `_jupyter_server_extension_points` function was not found in nbclassic. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
Enabling: reana_jupyterlab.server
- Writing config: /Users/tomondre/Projects/CERN/reana-jupyterlab-extension/.venv/etc/jupyter
    - Validating reana_jupyterlab.server...
      X Validation failed: validation failed
```