### PR TITLE
docs: add Tomas Ondrejka to the list of contributors in .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,6 +15,11 @@
             "orcid":"0000-0002-3403-1177",
             "affiliation": "CERN",
             "name": "Guerrieri, Giovanni"
+        },
+        {
+            "orcid":"0009-0009-0180-5197",
+            "affiliation": "CERN",
+            "name": "Tomas Ondrejka"
         }
     ],
 


### PR DESCRIPTION
* [`.zenodo.json`](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892R18-R22): Added "Tomas Ondrejka" as a contributor, including their ORCID (`0009-0009-0180-5197`) and affiliation ("CERN").