### PR TITLE
fix: typo in ci, variable name `python_version`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: "Base Setup: Node + Python"
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       with:
-        python_version: ${{ inputs.python-version }}
+        python_version: ${{ inputs.python_version }}
 
     - name: Install Python dependencies
       run: python -m pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: dev
+    branches: main
   pull_request:
     branches: '*'
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: main
+    branches: dev
   pull_request:
     branches: '*'
   workflow_dispatch:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/actions/test
       
       - name: Upload results to Codecov
-        if: matrix.python-version == '3.11'
+        if: matrix.python_version == '3.11'
         uses: codecov/codecov-action@v4
         with:
           file: coverage.xml


### PR DESCRIPTION
In the previous PR, I've noticed that the coverage wasn't uploaded to Codecov. The problem was that we were using `python-version` instead of `python_version` in `test` workflow and in `setup` action.

After fixing that, there were some problems while running the workflow with Python 3.8. As this version reached its end of life last year, I excluded it from the matrix and added a more recent version (Python 3.13)

- Fix the typo
- Update the versions tested (from 3.8-3.12 to 3.9-3.13)